### PR TITLE
Handle trivial warns GCC/clang/MSVC

### DIFF
--- a/include/boost/math/differentiation/autodiff_reverse.hpp
+++ b/include/boost/math/differentiation/autodiff_reverse.hpp
@@ -39,7 +39,7 @@ template<typename T, size_t order, class derived_expression>
 struct expression;
 
 template<typename T, size_t order>
-struct rvar;
+class rvar;
 
 template<typename T, size_t order, typename LHS, typename RHS, typename concrete_binary_operation>
 struct abstract_binary_expression;
@@ -104,8 +104,8 @@ public:
     gradient_tape &operator=(const gradient_tape &) = delete;
     gradient_tape(gradient_tape &&other)            = delete;
     gradient_tape operator=(gradient_tape &&other)  = delete;
-    ~gradient_tape() noexcept { clear(); }
-    void clear() noexcept
+    ~gradient_tape() { clear(); }
+    void clear()
     {
         adjoints_.clear();
         derivatives_.clear();
@@ -144,7 +144,7 @@ public:
         node->adjoint_                = adjoints_.emplace_back();
         // emulate if constexpr
         return fill_node_at_compile_time<n>(std::integral_constant<bool, (n > 0)>{}, node);
-    };
+    }
 
     // same as above at runtime
     gradient_node<T, order> *emplace_active_multi_node(size_t n)
@@ -246,26 +246,26 @@ public:
         : n_(n)
         , adjoint_(adjoint)
         , derivatives_(derivatives)
-    {}
+    { static_cast<void>(arguments); }
 
     inner_t get_adjoint_v() const { return *adjoint_; }
-    inner_t get_derivative_v(size_t arg_id) const { return derivatives_[arg_id]; };
+    inner_t get_derivative_v(size_t arg_id) const { return derivatives_[static_cast<ptrdiff_t>(arg_id)]; };
     inner_t get_argument_adjoint_v(size_t arg_id) const
     {
-        return *argument_nodes_[arg_id]->adjoint_;
+        return *argument_nodes_[static_cast<ptrdiff_t>(arg_id)]->adjoint_;
     }
 
     adjoint_iterator get_adjoint_ptr() { return adjoint_; }
     adjoint_iterator get_adjoint_ptr() const { return adjoint_; };
     void             update_adjoint_v(inner_t value) { *adjoint_ = value; };
-    void update_derivative_v(size_t arg_id, inner_t value) { derivatives_[arg_id] = value; };
+    void update_derivative_v(size_t arg_id, inner_t value) { derivatives_[static_cast<ptrdiff_t>(arg_id)] = value; };
     void update_argument_adj_v(size_t arg_id, inner_t value)
     {
-        argument_nodes_[arg_id]->update_adjoint_v(value);
+        argument_nodes_[static_cast<ptrdiff_t>(arg_id)]->update_adjoint_v(value);
     };
     void update_argument_ptr_at(size_t arg_id, gradient_node<T, order> *node_ptr)
     {
-        argument_nodes_[arg_id] = node_ptr;
+        argument_nodes_[static_cast<ptrdiff_t>(arg_id)] = node_ptr;
     }
 
     void backward()

--- a/include/boost/math/differentiation/detail/reverse_mode_autodiff_basic_operator_overloads.hpp
+++ b/include/boost/math/differentiation/detail/reverse_mode_autodiff_basic_operator_overloads.hpp
@@ -77,13 +77,13 @@ struct mult_expr
     inner_t              evaluate() const { return this->lhs.evaluate() * this->rhs.evaluate(); };
     static const inner_t left_derivative(const inner_t & /*l*/,
                                          const inner_t &r,
-                                         const inner_t & /*v*/)
+                                         const inner_t & /*v*/) noexcept
     {
         return r;
     };
     static const inner_t right_derivative(const inner_t &l,
                                           const inner_t & /*r*/,
-                                          const inner_t & /*v*/)
+                                          const inner_t & /*v*/) noexcept
     {
         return l;
     };

--- a/include/boost/math/differentiation/detail/reverse_mode_autodiff_expression_template_base.hpp
+++ b/include/boost/math/differentiation/detail/reverse_mode_autodiff_expression_template_base.hpp
@@ -20,7 +20,7 @@ template<typename T, size_t order, class derived_expression>
 struct expression;
 
 template<typename T, size_t order>
-struct rvar;
+class rvar;
 
 template<typename T, size_t order, typename LHS, typename RHS, typename concrete_binary_operation>
 struct abstract_binary_expression;
@@ -130,7 +130,7 @@ struct expression : expression_base
     {
         return static_cast<const derived_expression *>(this)->template propagatex<arg_index>(node,
                                                                                              adj);
-    };
+    }
 };
 
 template<typename T, size_t order, typename LHS, typename RHS, typename concrete_binary_operation>
@@ -159,11 +159,11 @@ struct abstract_binary_expression
     template<size_t arg_index>
     void propagatex(gradient_node<T, order> *node, inner_t adj) const
     {
-        inner_t lv        = lhs.evaluate();
-        inner_t rv        = rhs.evaluate();
-        inner_t v         = evaluate();
-        inner_t partial_l = concrete_binary_operation::left_derivative(lv, rv, v);
-        inner_t partial_r = concrete_binary_operation::right_derivative(lv, rv, v);
+        const inner_t lv        = lhs.evaluate();
+        const inner_t rv        = rhs.evaluate();
+        const inner_t v         = evaluate();
+        const inner_t partial_l = concrete_binary_operation::left_derivative(lv, rv, v);
+        const inner_t partial_r = concrete_binary_operation::right_derivative(lv, rv, v);
 
         constexpr size_t num_lhs_args = detail::count_rvars<LHS, order>;
         constexpr size_t num_rhs_args = detail::count_rvars<RHS, order>;

--- a/include/boost/math/differentiation/detail/reverse_mode_autodiff_memory_management.hpp
+++ b/include/boost/math/differentiation/detail/reverse_mode_autodiff_memory_management.hpp
@@ -137,7 +137,7 @@ public:
 
     flat_linear_allocator_iterator operator+(difference_type n) const
     {
-        return flat_linear_allocator_iterator(storage_, index_ + n, begin_, end_);
+        return flat_linear_allocator_iterator(storage_, index_ + static_cast<size_t>(n), begin_, end_);
     }
 
     flat_linear_allocator_iterator &operator+=(difference_type n)
@@ -185,7 +185,7 @@ public:
         return index_ >= other.index_;
     }
 
-    bool operator!() const { return storage_ == nullptr; }
+    bool operator!() const noexcept { return storage_ == nullptr; }
 };
 /* memory management helps for tape */
 template<typename T, size_t buffer_size>
@@ -216,8 +216,8 @@ public:
     using const_iterator
         = flat_linear_allocator_iterator<const flat_linear_allocator<T, buffer_size>, buffer_size>;
 
-    size_t buffer_id() const { return total_size_ / buffer_size; }
-    size_t item_id() const { return total_size_ % buffer_size; }
+    size_t buffer_id() const noexcept { return total_size_ / buffer_size; }
+    size_t item_id() const noexcept { return total_size_ % buffer_size; }
 
 private:
     void allocate_buffer()
@@ -316,7 +316,7 @@ public:
         new (ptr) T(std::forward<Args>(args)...);
         ++total_size_;
         return iterator(this, total_size_ - 1);
-    };
+    }
     /** @brief default constructs n objects at end of
    * data structure, n known at compile time */
     template<size_t n>


### PR DESCRIPTION
Hi @demroz these are the _very_ trivial warnings and messages I found in the first pass using both MSVC Intellisense as well as GCC and clang locally.

On GCC/clang, I like to be warning-free on the following (see below, even though I'm still working to get all of Math warn-free on these, I'd like new code to come in warn-free on these).

```
-Wall -Wextra -Wpedantic -Wconversion -Wsign-conversion
```